### PR TITLE
Tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module docmod
+module moddoc
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -1,15 +1,16 @@
-// Package main is the entry point for the docmod application.
+// Package main is the entry point for the moddoc application.
 //
 // moddoc outputs static html documentation for the given source directory.
 //
-// See the [mod.Module] structure for the structure that is passed to the main template for processing.
+// See the [moddoc/mod.Module] structure for the structure that is passed to the main template for processing.
 package main
 
 import (
-	"docmod/mod"
-	"docmod/tmpl"
 	"flag"
+	"fmt"
 	"log"
+	"moddoc/mod"
+	"moddoc/tmpl"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -81,11 +82,29 @@ func main() {
 
 	m := mod.NewModule(srcDir)
 
+	if err := createDirectoryIfNotExists(outDir); err != nil {
+		log.Fatalf("error creating output directory: %s", err)
+		return
+	}
+
 	for _, p := range m.Packages {
 		execPackageTemplate(packageTemplate, p, outDir)
 	}
 
 	execModuleTemplate(indexTemplate, m, outDir)
+}
+
+func createDirectoryIfNotExists(directoryPath string) error {
+	// Check if the directory already exists
+	if _, err := os.Stat(directoryPath); os.IsNotExist(err) {
+		// Directory does not exist, so create it
+		err := os.MkdirAll(directoryPath, 0755)
+		if err != nil {
+			return fmt.Errorf("failed to create directory: %v", err)
+		}
+	}
+
+	return nil
 }
 
 func execPackageTemplate(t *template.Template, p *mod.Package, outDir string) {

--- a/mod/module.go
+++ b/mod/module.go
@@ -107,7 +107,9 @@ func getPackages(dirPaths []string, modPath string, modImportPath string) (pkgs 
 			}
 
 			p := NewPackage(docPkg, fset, relPath, modImportPath)
-			pkgs = append(pkgs, p)
+			if p != nil {
+				pkgs = append(pkgs, p)
+			}
 		}
 
 	}

--- a/mod/package.go
+++ b/mod/package.go
@@ -1,8 +1,11 @@
 package mod
 
 import (
+	"bytes"
+	"go/ast"
 	"go/doc"
 	"go/doc/comment"
+	"go/format"
 	"go/token"
 	"log"
 	"os"
@@ -14,6 +17,9 @@ import (
 // StdLibSource is the URL for documentation of packages outside the module.
 const StdLibSource = `https://pkg.go.dev/`
 
+const hideCommand = "hide"
+const typeCommand = "type"
+
 type HTMLer interface {
 	toHTML(pkg *Package) string
 }
@@ -21,7 +27,7 @@ type HTMLer interface {
 // Package is a deconstruction of a package into its documentation parts for relatively easy consumption by a template.
 //
 // All strings listed are not escaped.
-// Call HTML on an item to convert it to html.
+// Call [HTML] on an item to convert it to html.
 type Package struct {
 	DocPkg *doc.Package
 	// Fset is the fileset of the files in package.
@@ -37,7 +43,9 @@ type Package struct {
 	Constants   []Constant
 	Variables   []Variable
 	Functions   []Function
-	Types       []Type
+	Types       []*Type
+	types       map[string]*Type // to manipulate the type after its inserted
+	//paths       map[string]struct{} // the set of valid paths in the package to know if we can link to them
 }
 
 // HTML should be called from within a template to convert the passed item to html.
@@ -62,15 +70,49 @@ func NewPackage(p *doc.Package, fset *token.FileSet, dirPath string, importRoot 
 	n.ImportPath = p.ImportPath
 	n.Path = dirPath + `/`
 	n.FileName = makeFileName(importRoot, dirPath, p.Name)
-	n.CommentHtml = n.parseHtmlComment(p.Doc)
+	cmt, flags := parseCommentFlags(p.Doc)
+	if _, ok := flags[hideCommand]; ok {
+		// We are being told to hide the package documentation completely
+		return nil
+	}
+	n.types = make(map[string]*Type)
+	n.CommentHtml = n.parseHtmlComment(cmt)
 	n.parseConstants()
 	n.parseVars()
 	n.parseFuncs()
 	n.parseTypes()
+	n.applyFlags()
 	return n
 }
 
-func (p *Package) parseHtmlComment(text string) string {
+const docPrefix = "doc:"
+
+// parseCommentFlags will search through the text and look for "doc:" commands, parse the commands, and return
+// the text with the commands removed.
+func parseCommentFlags(text string) (newText string, flags map[string]string) {
+	// Not the fastest implementation, but the most supportable perhaps
+	lines := strings.SplitAfter(text, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, docPrefix) {
+			if flags == nil {
+				flags = make(map[string]string)
+			}
+			parts := strings.Split(line[len(docPrefix):], "=")
+			if len(parts) == 2 {
+				flags[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+			} else {
+				flags[strings.TrimSpace(parts[0])] = "" // a boolean flag
+			}
+		} else {
+			newText += line
+		}
+	}
+	return
+}
+
+func (p *Package) parseHtmlComment(text string) (html string) {
+	// Parse out the flags and adjust the text
+
 	parser := p.DocPkg.Parser().Parse(text)
 	printer := p.DocPkg.Printer()
 
@@ -81,9 +123,9 @@ func (p *Package) parseHtmlComment(text string) string {
 			l = strings.TrimPrefix(l, "/")
 			url = makeFileName(p.ModuleName, l, p.Name)
 		} else if strings.ContainsRune(link.ImportPath, '.') {
-			// A path to a url
-			url = "http://" + link.ImportPath
-		} else {
+			// Indicates this is a path to a URL
+			url = "https://" + link.ImportPath
+		} else if link.ImportPath != "" {
 			// assume this is a link to the standard library, so point to online doc
 			url = StdLibSource + link.ImportPath
 		}
@@ -98,7 +140,8 @@ func (p *Package) parseHtmlComment(text string) string {
 		return
 	}
 	c := printer.HTML(parser)
-	return string(c)
+	html = string(c)
+	return
 }
 
 func makeFileName(importRoot string, dirPath string, packageName string) string {
@@ -119,14 +162,19 @@ func makeFileName(importRoot string, dirPath string, packageName string) string 
 func (p *Package) parseConstant(c *doc.Value) Constant {
 	var c2 Constant
 	c2.Names = c.Names
-	c2.CommentHtml = p.parseHtmlComment(c.Doc)
-	c2.Code = p.getCodeFragment(c.Decl.Pos(), c.Decl.End())
+	cmt, flags := parseCommentFlags(c.Doc)
+	c2.Flags = flags
+	c2.CommentHtml = p.parseHtmlComment(cmt)
+	c2.Code, _ = p.generateCode(c.Decl)
 	return c2
 }
 
 func (p *Package) parseConstants() {
 	for _, c := range p.DocPkg.Consts {
-		p.Constants = append(p.Constants, p.parseConstant(c))
+		newC := p.parseConstant(c)
+		if _, ok := newC.Flags[hideCommand]; !ok {
+			p.Constants = append(p.Constants, newC)
+		}
 	}
 }
 
@@ -149,42 +197,71 @@ func (p *Package) getCodeFragment(start token.Pos, end token.Pos) string {
 	return string(b)
 }
 
+func (p *Package) generateCode(decl ast.Decl) (string, error) {
+	// Create an AST node slice containing only the target GenDecl.
+	astFile := &ast.File{
+		Name:  ast.NewIdent("main"),
+		Decls: []ast.Decl{decl},
+	}
+
+	buf := bytes.Buffer{}
+	err := format.Node(&buf, p.Fset, astFile)
+	if err != nil {
+		return "", err
+	}
+	s := buf.String()
+	// remove the package preamble
+	return s[14:], nil
+}
+
 func (p *Package) parseVariable(v *doc.Value) Variable {
 	var v2 Variable
 	v2.Names = v.Names
-	v2.CommentHtml = p.parseHtmlComment(v.Doc)
-	v2.Code = p.getCodeFragment(v.Decl.Pos(), v.Decl.End())
+	cmt, flags := parseCommentFlags(v.Doc)
+	v2.Flags = flags
+	v2.CommentHtml = p.parseHtmlComment(cmt)
+	v2.Code, _ = p.generateCode(v.Decl)
 	return v2
 }
 
 func (p *Package) parseVars() {
 	for _, v := range p.DocPkg.Vars {
-		p.Variables = append(p.Variables, p.parseVariable(v))
+		newV := p.parseVariable(v)
+		if _, ok := newV.Flags[hideCommand]; !ok {
+			p.Variables = append(p.Variables, newV)
+		}
 	}
 }
 
 func (p *Package) parseFunction(f *doc.Func) Function {
 	var f2 Function
 	f2.Name = f.Name
-	f2.CommentHtml = p.parseHtmlComment(f.Doc)
+	cmt, flags := parseCommentFlags(f.Doc)
+	f2.Flags = flags
+	f2.CommentHtml = p.parseHtmlComment(cmt)
 	f2.Code = p.getCodeFragment(f.Decl.Pos(), f.Decl.End())
 	return f2
 }
 
 func (p *Package) parseFuncs() {
 	for _, f := range p.DocPkg.Funcs {
-		p.Functions = append(p.Functions, p.parseFunction(f))
+		newF := p.parseFunction(f)
+		if _, ok := newF.Flags[hideCommand]; !ok {
+			p.Functions = append(p.Functions, newF)
+		}
 	}
 }
 
 func (p *Package) parseMethod(f *doc.Func) Method {
 	var f2 Method
 	f2.Name = f.Name
-	f2.CommentHtml = p.parseHtmlComment(f.Doc)
-	f2.Code = p.getCodeFragment(f.Decl.Pos(), f.Decl.End())
+	cmt, flags := parseCommentFlags(f.Doc)
+	f2.Flags = flags
+	f2.CommentHtml = p.parseHtmlComment(cmt)
+	f2.Code, _ = p.generateCode(f.Decl)
 
-	f2.Receiver = f.Orig
-	f2.EmbeddedType = f.Recv
+	f2.Receiver = f.Recv
+	f2.EmbeddedType = f.Orig
 	f2.Level = f.Level
 	return f2
 }
@@ -193,23 +270,129 @@ func (p *Package) parseTypes() {
 	for _, t := range p.DocPkg.Types {
 		var t2 Type
 		t2.Name = t.Name
-		t2.CommentHtml = p.parseHtmlComment(t.Doc)
-		t2.Code = p.getCodeFragment(t.Decl.Pos(), t.Decl.End())
+		cmt, flags := parseCommentFlags(t.Doc)
+		if _, ok := flags[hideCommand]; ok {
+			continue // skip
+		}
+		t2.Flags = flags
+		t2.CommentHtml = p.parseHtmlComment(cmt)
+		t2.Code, _ = p.generateCode(t.Decl)
 
 		for _, c := range t.Consts {
-			t2.Constants = append(p.Constants, p.parseConstant(c))
+			item := p.parseConstant(c)
+			if _, ok := item.Flags[hideCommand]; !ok {
+				t2.Constants = append(t2.Constants, item)
+			}
 		}
 		for _, v := range t.Vars {
-			t2.Variables = append(t2.Variables, p.parseVariable(v))
+			item := p.parseVariable(v)
+			if _, ok := item.Flags[hideCommand]; !ok {
+				t2.Variables = append(t2.Variables, item)
+			}
 		}
 		for _, f := range t.Funcs {
-			t2.Functions = append(t2.Functions, p.parseFunction(f))
+			item := p.parseFunction(f)
+			if _, ok := item.Flags[hideCommand]; !ok {
+				t2.Functions = append(t2.Functions, item)
+			}
 		}
 
 		for _, f := range t.Methods {
-			t2.Methods = append(t2.Methods, p.parseMethod(f))
+			item := p.parseMethod(f)
+			if _, ok := item.Flags[hideCommand]; !ok {
+				t2.Methods = append(t2.Methods, item)
+			}
 		}
 
-		p.Types = append(p.Types, t2)
+		pT := &t2
+		p.Types = append(p.Types, pT)
+		p.types[t2.Name] = pT // to get to types by name
 	}
 }
+
+// applyFlags will apply the flag values that were parsed earlier, deleting or moving specific objects as needed.
+func (p *Package) applyFlags() {
+	var newConstants []Constant
+	for _, item := range p.Constants {
+		if t := item.Flags[typeCommand]; t != "" {
+			if pT := p.types[t]; pT != nil {
+				pT.Constants = append(pT.Constants, item)
+			} else {
+				log.Printf("Warning: type %s not found in comment for constant %s", t, item.Names[0])
+				newConstants = append(newConstants, item)
+			}
+		} else {
+			newConstants = append(newConstants, item)
+		}
+	}
+	p.Constants = newConstants
+
+	var newVars []Variable
+	for _, item := range p.Variables {
+		if t := item.Flags[typeCommand]; t != "" {
+			if pT := p.types[t]; pT != nil {
+				pT.Variables = append(pT.Variables, item)
+			} else {
+				log.Printf("Warning: type %s not found in comment for variable %s", t, item.Names[0])
+				newVars = append(newVars, item)
+			}
+		} else {
+			newVars = append(newVars, item)
+		}
+	}
+	p.Variables = newVars
+
+	var newFuncs []Function
+	for _, item := range p.Functions {
+		if t := item.Flags[typeCommand]; t != "" {
+			if pT := p.types[t]; pT != nil {
+				pT.Functions = append(pT.Functions, item)
+			} else {
+				log.Printf("Warning: type %s not found in comment for function %s", t, item.Name)
+				newFuncs = append(newFuncs, item)
+			}
+		} else {
+			newFuncs = append(newFuncs, item)
+		}
+	}
+	p.Functions = newFuncs
+}
+
+/*
+
+func (p *Package) collectPaths() {
+	p.paths = make(map[string]struct{})
+
+	for _, c := range p.Constants {
+		for _, n := range c.Names {
+			p.paths[n] = struct{}{}
+		}
+	}
+	for _, v := range p.Variables {
+		for _, n := range v.Names {
+			p.paths[n] = struct{}{}
+		}
+	}
+	for _, f := range p.Functions {
+		p.paths[f.Name] = struct{}{}
+	}
+	for _, t := range p.Types {
+		for _, c := range t.Constants {
+			for _, n := range c.Names {
+				p.paths[t.Name+"."+n] = struct{}{}
+			}
+		}
+		for _, v := range t.Variables {
+			for _, n := range v.Names {
+				p.paths[t.Name+"."+n] = struct{}{}
+			}
+		}
+		for _, f := range t.Functions {
+			p.paths[t.Name+"."+f.Name] = struct{}{}
+		}
+		for _, m := range t.Methods {
+			p.paths[t.Name+"."+m.Name] = struct{}{}
+		}
+	}
+}
+*/

--- a/mod/package_test.go
+++ b/mod/package_test.go
@@ -1,0 +1,33 @@
+package mod
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parseCommentFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		text        string
+		wantNewText string
+		wantFlags   map[string]string
+	}{
+		{"empty", "", "", nil},
+		{"noflags", "abc", "abc", nil},
+		{"noflags 2 lines", "abc\njkl", "abc\njkl", nil},
+		{"bool flag", "doc: abc", "", map[string]string{"abc": ""}},
+		{"val flag", "doc: abc=def", "", map[string]string{"abc": "def"}},
+		{"2 lines", "doc: abc=def\ndoc:ghi", "", map[string]string{"abc": "def", "ghi": ""}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNewText, gotFlags := parseCommentFlags(tt.text)
+			if gotNewText != tt.wantNewText {
+				t.Errorf("parseCommentFlags() gotNewText = %v, want %v", gotNewText, tt.wantNewText)
+			}
+			if !reflect.DeepEqual(gotFlags, tt.wantFlags) {
+				t.Errorf("parseCommentFlags() gotFlags = %v, want %v", gotFlags, tt.wantFlags)
+			}
+		})
+	}
+}

--- a/mod/types.go
+++ b/mod/types.go
@@ -5,6 +5,7 @@ type Constant struct {
 	Code        string
 	Names       []string
 	CommentHtml string
+	Flags       map[string]string
 }
 
 // Variable represents a variable declaration, or a group of variables declared together with the same type.
@@ -12,6 +13,7 @@ type Variable struct {
 	Code        string
 	Names       []string
 	CommentHtml string
+	Flags       map[string]string
 }
 
 // Function represents a simple top-level function that is not associated with a type.
@@ -19,6 +21,7 @@ type Function struct {
 	Code        string
 	Name        string
 	CommentHtml string
+	Flags       map[string]string
 }
 
 // Method represents a method associated with a type.
@@ -32,6 +35,7 @@ type Method struct {
 	// EmbeddedType is the name of the type this method is associated with if its embedded in the main type.
 	EmbeddedType string
 	Level        int
+	Flags        map[string]string
 }
 
 // Type represents a type definition.
@@ -40,6 +44,7 @@ type Type struct {
 	Code        string
 	Name        string
 	CommentHtml string
+	Flags       map[string]string
 	Constants   []Constant
 	Variables   []Variable
 	Functions   []Function

--- a/testdata/in/constants.go
+++ b/testdata/in/constants.go
@@ -1,8 +1,8 @@
 // Package in contains test data.
 package in
 
-// TestConstantString is a string typed test constant
-const TestConstantString = "test string" // a string
+// TestConstantString is A string typed test constant
+const TestConstantString = "test string" // A string
 
 // TestConstantInt is an int typed test constant
 const TestConstantInt = 2 // an int
@@ -10,6 +10,7 @@ const TestConstantInt = 2 // an int
 // A group of test constants
 const (
 	// TestOne is the first item in the test group
-	TestOne = iota + 1
-	TestTwo // This is a comment on the same line
+	TestOne   = iota + 1
+	TestTwo   // This is A comment on the same line
+	testThree // is not exported
 )

--- a/testdata/in/funcs.go
+++ b/testdata/in/funcs.go
@@ -1,11 +1,17 @@
 package in
 
-// notExported is a function that is not exported.
+import "moddoc/mod"
+
+// notExported is A function that is not exported.
 func notExported() {
 	_ = 1
 }
 
-// Exported is a function that is exported.
+// Exported is A function that is exported.
+//
+// Here I am testing A package import link to [mod.Module]
+// And here I am testing A link to A local, moved, function [ILikeMyType]
 func Exported() {
 	_ = 2
+	_ = mod.Module{}
 }

--- a/testdata/in/types.go
+++ b/testdata/in/types.go
@@ -1,0 +1,52 @@
+package in
+
+import "fmt"
+
+// MyType is a test type
+type MyType struct {
+	// A is an exported type
+	A int
+	// b is an unexported type
+	b int
+	// C is also exported
+	C string
+}
+
+// Init initializes the MyType object
+func (m *MyType) Init() {
+	m.A = 1
+	m.b = Bstart
+}
+
+// private is a private method that should not generally appear in the doc unless asked for.
+func (m *MyType) private() {
+	m.A = 3
+}
+
+// ILikeMyType prints A message about MyType
+//
+// This is here to test the "type" doc command, that will associate this function with the [MyType] type.
+//
+// doc: type=MyType
+func ILikeMyType() {
+	fmt.Print("I like my types")
+}
+
+// Bstart is the initialized value of B
+//
+// doc: type=MyType
+const Bstart = 4
+
+// Dummy is A dummy value to test the hide command of moddoc
+// doc: hide
+const Dummy = 5
+
+// MyiFace is an interface type
+type MyiFace interface {
+	// Here goes over here
+	Here() // and this has an inline comment
+	// There goes over there
+	There()
+	// where goes wherever
+	where()
+}

--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -39,8 +39,7 @@
 <h2 id="Functions">Functions</h2>
 {{if not .Functions}} <p>This section is empty. {{end}}
 {{ range .Functions }}
-<h3 id="{{.Name}}" class="func-name">func <i>{{.Name}}</i></h3>
-<pre>{{.Code}}</pre>
+<h3 id="{{.Name}}" class="func-name"><pre>{{.Code}}</pre></h3>
 {{.CommentHtml}}
 {{end}}
 
@@ -52,6 +51,7 @@
 <pre>{{.Code}}</pre>
 {{.CommentHtml}}
 
+{{if .Constants}}<h3 id = "{{ .Name}}.Constants">Constants</h3>{{end}}
 {{ range .Constants }}
 {{range .Names}}
 <a id="{{$typename}}.{{.}}"></a>
@@ -60,6 +60,7 @@
 {{.CommentHtml}}
 {{end}}
 
+{{if .Variables}}<h3 id = "{{ .Name}}.Variables">Variables</h3>{{end}}
 {{ range .Variables }}
 {{range .Names}}
 <a id="{{$typename}}.{{.}}"></a>
@@ -68,15 +69,16 @@
 {{.CommentHtml}}
 {{end}}
 
+{{if .Functions}}<h3 id = "{{ .Name}}.Functions">Functions</h3>{{end}}
 {{ range .Functions }}
-<h4 id="{{$typename}}.{{.Name}}" class="func-name">func <i>{{.Name}}</i></h4>
-<pre>{{.Code}}</pre>
+<h4 id="{{$typename}}.{{.Name}}" class="func-name"><pre>{{.Code}}</pre></h4>
 {{.CommentHtml}}
 {{end}}
 
+{{if .Methods}}<h3 id = "{{ .Name}}.Methods">Methods</h3>{{end}}
 {{ range .Methods }}
-<h4 id="{{$typename}}.{{.Name}}" class="method-name">func ({{.Receiver}}) <i>{{.Name}}</i></h4>
-<pre>{{.Code}}</pre>
+<h4 id="{{$typename}}.{{.Name}}" class="method-name"><pre>{{.Code}}</pre></h4>
+
 {{.CommentHtml}}
 {{end}}
 


### PR DESCRIPTION
Added a doc: tag to comments to add further controls to how comments are generated and where they are located. Improved how code is generated. Making sure non-exported types and names are not shown.